### PR TITLE
EZP-22641: Handled asynchronous publishing

### DIFF
--- a/design/standard/override/templates/content/view/line_thumbnail/article.tpl
+++ b/design/standard/override/templates/content/view/line_thumbnail/article.tpl
@@ -1,0 +1,21 @@
+<div class="content-view-line-thumbnail">
+    <div class="class-{$object.class_identifier}">
+        {def $href=cond( is_set( $object.main_node ), $object.main_node.url_alias|ezurl, true(), false() )}
+        {if $href}
+            <h2><a href={$href} title="{$object.name|wash}">{$object.name|shorten(17)|wash}</a></h2>
+        {else}
+            <h2>{$object.name|shorten(17)|wash}</h2>
+        {/if}
+        {if $object.data_map.image.has_content}
+        <div class="attribute-image">
+            {attribute_view_gui image_class=articlethumbnail href=$href attribute=$object.data_map.image}
+        </div>
+        {/if}
+        {if $object.data_map.intro.has_content}
+        <div class="attribute-short"> 
+            <p>{$object.data_map.intro.content.output.output_text|strip_tags()|shorten(45)|wash}</p>
+        </div>
+        {/if}
+        <div class="thumbnail-class-name"><p>{$object.class_name|wash}</p></div>
+    </div>
+</div>

--- a/design/standard/override/templates/content/view/line_thumbnail/file.tpl
+++ b/design/standard/override/templates/content/view/line_thumbnail/file.tpl
@@ -1,0 +1,14 @@
+<div class="content-view-line-thumbnail">
+    <div class="class-{$object.class_identifier}">
+        {def $href=cond( is_set( $object.main_node ), $object.main_node.url_alias|ezurl, true(), false() )}
+        {if $href}
+            <h2><a href={$href} title="{$object.name|wash}">{$object.name|shorten(17)|wash}</a></h2>
+        {else}
+            <h2>{$object.name|shorten(17)|wash}</h2>
+        {/if}
+        <div class="content-file">
+            <p>{attribute_view_gui attribute=$object.data_map.file}</p>
+        </div>
+        <div class="thumbnail-class-name"><p>{$object.class_name|wash}</p></div>
+    </div>
+</div>

--- a/design/standard/override/templates/content/view/line_thumbnail/flash_player.tpl
+++ b/design/standard/override/templates/content/view/line_thumbnail/flash_player.tpl
@@ -1,0 +1,14 @@
+<div class="content-view-line-thumbnail">
+    <div class="class-{$object.class_identifier}">
+        {def $href=cond( is_set( $object.main_node ), $object.main_node.url_alias|ezurl, true(), false() )}
+        {if $href}
+            <h2><a href={$href} title="{$object.name|wash}">{$object.name|shorten(17)|wash}</a></h2>
+        {else}
+            <h2>{$object.name|wash|shorten(17)}</h2>
+        {/if}
+        <div class="thumbnail-movie-icon">
+            <img src={"ezmultiupload-movie.png"|ezimage} />
+        <div>
+        <div class="thumbnail-class-name"><p>{$object.class_name|wash}</p></div>
+    </div>
+</div>

--- a/design/standard/override/templates/content/view/line_thumbnail/image.tpl
+++ b/design/standard/override/templates/content/view/line_thumbnail/image.tpl
@@ -1,0 +1,14 @@
+<div class="content-view-line-thumbnail">
+    <div class="class-{$object.class_identifier}">
+        {def $href=cond( is_set( $object.main_node ), $object.main_node.url_alias|ezurl, true(), false() )}
+        {if $href}
+            <h2><a href={$href} title="{$object.name|wash}">{$object.name|shorten(17)|wash}</a></h2>
+        {else}
+            <h2>{$object.name|shorten(17)|wash}</h2>
+        {/if}
+        <div class="content-image">
+            {attribute_view_gui attribute=$object.data_map.image image_class=multiuploadthumbnail href=$href}
+        </div>
+        <div class="thumbnail-class-name"><p>{$object.class_name|wash}</p></div>
+    </div>
+</div>

--- a/design/standard/templates/content/view/line_thumbnail.tpl
+++ b/design/standard/templates/content/view/line_thumbnail.tpl
@@ -1,0 +1,11 @@
+<div class="content-view-line-thumbnail">
+    <div class="class-{$object.class_identifier}">
+        {def $href=cond( is_set( $object.main_node ), $object.main_node.url_alias|ezurl, true(), false() )}
+        {if $href}
+            <h2><a href={$href} title="{$object.name|wash}">{$object.name|shorten(17)|wash}</a></h2>
+        {else}
+            <h2>{$object.name|shorten(17)|wash}</h2>
+        {/if}
+        <div class="thumbnail-class-name"><p>{$object.class_name|wash}</p></div>
+    </div>
+</div>

--- a/design/standard/templates/ezmultiupload/thumbnail.tpl
+++ b/design/standard/templates/ezmultiupload/thumbnail.tpl
@@ -7,6 +7,8 @@
         {/foreach}
         </ul>
     </div>
-{elseif is_set( $result.contentobject )}
+{elseif is_set( $result.contentobject.main_node )}
     {node_view_gui view='line_thumbnail' content_node=$result.contentobject.main_node}
+{elseif is_set( $result.contentobject )}
+    {content_view_gui view='line_thumbnail' content_object=$result.contentobject}
 {/if}

--- a/modules/ezmultiupload/upload.php
+++ b/modules/ezmultiupload/upload.php
@@ -24,6 +24,11 @@ if( $module->isCurrentAction( 'Upload' ) )
     // Handle file upload only if there was no errors
     if( empty( $result['errors'] ) )
     {
+        $behaviour = new ezpContentPublishingBehaviour();
+        $behaviour->isTemporary = true;
+        $behaviour->disableAsynchronousPublishing = false;
+        ezpContentPublishingBehaviour::setBehaviour( $behaviour );
+
         // Handle file upload. All checkes are performed by eZContentUpload::handleUpload()
         // and available in $result array
         $upload = new eZContentUpload();

--- a/settings/override.ini.append.php
+++ b/settings/override.ini.append.php
@@ -1,27 +1,52 @@
 <?php /*
 
 [line_thumbnail_image]
+Source=content/view/line_thumbnail.tpl
+MatchFile=content/view/line_thumbnail/image.tpl
+Subdir=templates
+Match[class_identifier]=image
+
+[line_thumbnail_article]
+Source=content/view/line_thumbnail.tpl
+MatchFile=content/view/line_thumbnail/article.tpl
+Subdir=templates
+Match[class_identifier]=article
+
+[line_thumbnail_flash_player]
+Source=content/view/line_thumbnail.tpl
+MatchFile=content/view/line_thumbnail/flash_player.tpl
+Subdir=templates
+Match[class_identifier]=flash_player
+
+[line_thumbnail_file]
+Source=content/view/line_thumbnail.tpl
+MatchFile=content/view/line_thumbnail/file.tpl
+Subdir=templates
+Match[class_identifier]=file
+
+
+# Kept for BC, see EZP-22641
+
+[node_line_thumbnail_image]
 Source=node/view/line_thumbnail.tpl
 MatchFile=line_thumbnail/image.tpl
 Subdir=templates
 Match[class_identifier]=image
 
-[line_thumbnail_article]
+[node_line_thumbnail_article]
 Source=node/view/line_thumbnail.tpl
 MatchFile=line_thumbnail/article.tpl
 Subdir=templates
 Match[class_identifier]=article
 
-[line_thumbnail_flash_player]
+[node_line_thumbnail_flash_player]
 Source=node/view/line_thumbnail.tpl
 MatchFile=line_thumbnail/flash_player.tpl
 Subdir=templates
 Match[class_identifier]=flash_player
 
-[line_thumbnail_file]
+[node_line_thumbnail_file]
 Source=node/view/line_thumbnail.tpl
-MatchFile=line_thumbnail/file.tpl
+MatchFile=node/view/line_thumbnail/file.tpl
 Subdir=templates
 Match[class_identifier]=file
-
-*/ ?>


### PR DESCRIPTION
> Backport of ezsystems/ezmultiupload#11

Unlike the master version, this one doesn't remove the node/view/line_thumbnail.tpl overrides. Instead, it uses `node_view_gui` if the content has a main node, and content_view_gui if it doesn't. This should avoid any BC break in overrides configuration.
