### PR TITLE
Fix EZP-27090: Upload file button display

### DIFF
--- a/design/standard/javascript/ezmultiupload.js
+++ b/design/standard/javascript/ezmultiupload.js
@@ -17,8 +17,6 @@ YUI.add('ezmultiupload', function (Y) {
 
             Y.ez.MultiUpload.uploader.uploadAll(Y.ez.MultiUpload.cfg.uploadURL, Y.ez.MultiUpload.cfg.uploadVars);
 
-            Y.one('#uploadButton').disabled = true;
-
             var cancelUploadButton = Y.one('#cancelUploadButton');
             cancelUploadButton.setStyle('visibility', 'visible');
             cancelUploadButton.on('click', cancelUpload, this, true);
@@ -52,7 +50,6 @@ YUI.add('ezmultiupload', function (Y) {
             Y.one('#multiuploadProgressMessage').setHTML(Y.ez.MultiUpload.cfg.thumbnailCreated);
             Y.one('#multiuploadProgressBar').setStyle('width', '100%');
 
-            Y.one('#uploadButton').disabled = false;
             Y.one('#multiuploadProgressMessage').setHTML(Y.ez.MultiUpload.cfg.allFilesRecived);
 
             var fileCount = Y.ez.MultiUpload.originalFileList.length;
@@ -94,7 +91,6 @@ YUI.add('ezmultiupload', function (Y) {
             Y.ez.MultiUpload.uploader.set('fileList', []);
 
             Y.one('#multiuploadProgressMessage').setHTML(Y.ez.MultiUpload.cfg.uploadCanceled);
-            Y.one('#uploadButton').disabled = false;
         };
 
         var fadeAnimate = function (elementID, fromValue, toValue) {
@@ -142,12 +138,6 @@ YUI.add('ezmultiupload', function (Y) {
 
             init: function () {
                 Y.on('domready', function () {
-                    var uploadButton = Y.one('#uploadButton');
-                    var overlay = Y.one('#uploadButtonOverlay');
-
-                    overlay.setStyle('width', uploadButton.right - uploadButton.left + "px");
-                    overlay.setStyle('height', uploadButton.bottom - uploadButton.top + "px");
-
                     Y.Uploader = Y.UploaderHTML5;
                     Y.ez.MultiUpload.uploader = new Y.Uploader();
 

--- a/design/standard/javascript/ezmultiupload.js
+++ b/design/standard/javascript/ezmultiupload.js
@@ -139,7 +139,7 @@ YUI.add('ezmultiupload', function (Y) {
             init: function () {
                 Y.on('domready', function () {
                     Y.Uploader = Y.UploaderHTML5;
-                    Y.ez.MultiUpload.uploader = new Y.Uploader();
+                    Y.ez.MultiUpload.uploader = new Y.Uploader({selectButtonLabel: Y.ez.MultiUpload.cfg.selectButtonLabel});
 
                     if (Y.Uploader.TYPE == "html5") {
                         Y.ez.MultiUpload.uploader.set("uploadURL", Y.ez.MultiUpload.cfg.uploadURL);

--- a/design/standard/templates/ezmultiupload/upload.tpl
+++ b/design/standard/templates/ezmultiupload/upload.tpl
@@ -22,6 +22,7 @@
             allFilesRecived:  "{'All files received.'|i18n('extension/ezmultiupload')|wash(javascript)}",
             uploadCanceled:   "{'Upload canceled.'|i18n('extension/ezmultiupload')|wash(javascript)}",
             thumbnailCreated: "{'Thumbnail created.'|i18n('extension/ezmultiupload')|wash(javascript)}",
+            selectButtonLabel: "{'Select files'|i18n('extension/ezmultiupload')|wash(javascript)}",
             multipleFiles: true
         {rdelim};
         Y.ez.MultiUpload.init();

--- a/design/standard/templates/ezmultiupload/upload.tpl
+++ b/design/standard/templates/ezmultiupload/upload.tpl
@@ -42,7 +42,6 @@
         <div class="attribute-description">
             <p>{'The files are uploaded to'|i18n('extension/ezmultiupload')} <a href={$parent_node.url_alias|ezurl}>{$parent_node.name|wash}</a></p>
             <div id="uploadButtonOverlay" style="position: absolute; z-index: 2"></div>
-            <button id="uploadButton" type="button" style="z-index: 1">{'Select files'|i18n('extension/ezmultiupload')}</button>
             <button id="cancelUploadButton" type="button">{'Cancel'|i18n('extension/ezmultiupload')}</button>
             <p><noscript><em style="color: red;">{'Javascript has been disabled, this is needed for multiupload!'|i18n('extension/ezmultiupload')}</em></noscript></p>
         </div>


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-27090

## Description
This PR fixes two issues:
- The old upload button (before we migrated the to YUI 3 in #16) was still displayed (as before it used to be overlayed by the javascript one) and has been removed.
- The label of the select button was not translated.

## Tests
Manual tests on Firefox and Chrome